### PR TITLE
[Chore] GitHub 템플릿 및 컨벤션 수정

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -6,47 +6,55 @@ module.exports = {
       rules: {
         'subject-has-issue': (parsed) => {
           const { subject } = parsed;
+
           if (!subject) {
-            return [false, '커밋 메시지에 설명이 없습니다.'];
+            return [false, '❌ 커밋 메시지의 설명(Subject)이 없습니다.'];
           }
-          return /#[0-9]+$/.test(subject)
-            ? [true]
-            : [
-                false,
-                '커밋 메시지 끝에 "#이슈번호"를 포함해야 합니다. ex: feat: OOO 기능 #7',
-              ];
+
+          // 이슈 번호 검증: "#숫자" 형식이 마지막에 포함되어야 함
+          const issuePattern = /#\d+$/;
+          if (!issuePattern.test(subject.trim())) {
+            return [
+              false,
+              '❌ 커밋 메시지 끝에 "#이슈번호"를 포함해야 합니다.\n예시: feat: 새로운 기능 추가 #42',
+            ];
+          }
+
+          return [true];
         },
       },
     },
   ],
 
   rules: {
-    // 2-1) type(키워드) 허용 목록
+    // ✅ 1) type(키워드) 허용 목록
     'type-enum': [
       2,
       'always',
       [
-        'feat',
-        'docs',
-        'config',
-        'style',
-        'refactor',
-        'test',
-        'chore',
-        'fix',
-        'hotfix',
+        'feat', // 새로운 기능 관련 작업
+        'docs', // 문서 작업
+        'config', // 프로젝트 설정 관련 작업
+        'design', // UI/UX 관련 스타일 작업
+        'style', // 코드 스타일 관련 작업
+        'refactor', // 코드 리팩토링 작업
+        'test', // 테스트 코드 관련 작업
+        'chore', // 기타 작업
+        'fix', // 버그 및 수정 사항 관련 작업
+        'hotfix', // 치명적인 버그 수정 작업
       ],
     ],
 
-    // 2-2) type(키워드)는 무조건 소문자
+    // ✅ 2) type(키워드)는 무조건 소문자로 작성해야 함
     'type-case': [2, 'always', 'lower-case'],
 
-    // 2-3) 커밋 메시지에 “서브젝트(설명)”는 비어 있으면 안 됨
+    // ✅ 3) subject(설명)는 반드시 존재해야 함
     'subject-empty': [2, 'never'],
 
-    // 2-4) “마지막에 #이슈번호가 있어야 한다”는 커스텀 검사
+    // ✅ 4) subject의 마지막에 #이슈번호를 포함해야 함
     'subject-has-issue': [2, 'always'],
 
+    // ✅ 5) subject(설명)는 대소문자 제한 없이 자유롭게 작성 가능
     'subject-case': [0],
   },
 };

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: ⚡ Feature
 description: 새로운 기능이나 변경사항이 있나요?
-title: '[Feature] '
+title: '[Feat] '
 labels: ['⚡ Feature']
 body:
   - type: textarea

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -9,12 +9,13 @@
 
 ####################
 
-# feat : 새로운 기능 추가
-# docs : 문서 수정
-# config : 프로젝트 설정 변경
-# style : UI/UX 관련 스타일 변경
-# refactor : 코드 리팩토링
-# test : 테스트 코드 추가 및 수정
+# feat : 새로운 기능 관련 작업
+# docs : 문서 작업
+# config : 프로젝트 설정 관련 작업
+# design : UI/UX 관련 스타일 작업
+# style : 코드 스타일 관련 작업
+# refactor : 코드 리팩토링 작업
+# test : 테스트 코드 관련 작업
 # chore : 기타 작업
-# fix : 버그 및 수정사항 반영
-# hotfix : 치명적인 버그 수정
+# fix : 버그 및 수정 사항 관련 작업
+# hotfix : 치명적인 버그 수정 작업


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

GitHub 템플릿 및 컨벤션 일부 수정

## 📋 작업 내용

- 기존 UI/UX 관련 작업에 해당하는 **Style** 키워드에서 **Design** 키워드로 변경
- 코드 스타일(포맷) 관련 내용은 **Style** 키워드에서 작업
- 기존 **Feature** 키워드에 해당하는 내용은 앞으로 일괄 Feat 키워드로 통일

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.

## Sourcery 요약

프로젝트의 commitlint 구성 및 이슈 템플릿을 업데이트하여 커밋 메시지 규칙을 적용하고 키워드를 표준화합니다.

개선 사항:
- 커밋 메시지 제목 끝에 이슈 번호 포함을 강제하도록 commitlint 구성을 업데이트합니다.

잡일:
- UI/UX 관련 작업을 위해 커밋 유형의 `Style` 키워드를 `Design`으로 변경합니다.
- 이슈 템플릿 및 커밋 유형에서 `Feature` 대신 `Feat` 키워드를 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the project's commitlint configuration and issue templates to enforce commit message conventions and standardize keywords.

Enhancements:
- Update commitlint configuration to enforce issue number inclusion at the end of the commit message subject.

Chores:
- Rename the `Style` keyword in commit types to `Design` for UI/UX related tasks.
- Use the `Feat` keyword instead of `Feature` in issue templates and commit types.

</details>