### PR TITLE
[Feat] 포스트 상세 페이지 부가 기능 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ const Home = async (props: HomeProps) => {
   return (
     <div className='w-full px-2 select-none'>
       <div className='py-5'>
-        <h1 className='inline font-recipekorea text-2xl md:text-3xl font-bold hover:text-secondary dark:text-text-dark dark:hover:text-secondary'>
+        <h1 className='inline font-recipekorea text-2xl md:text-3xl font-bold hover:text-secondary dark:text-text-dark dark:hover:text-blue-600'>
           TAGS
         </h1>
         <div className='flex my-4 p-3 md:p-4 gap-1 md:gap-2 flex-wrap shadow-md bg-white rounded-lg dark:bg-darkActive'>
@@ -55,7 +55,7 @@ const Home = async (props: HomeProps) => {
         </div>
       </div>
       <div className='py-5'>
-        <h1 className='inline font-recipekorea text-2xl md:text-3xl font-bold hover:text-secondary dark:text-text-dark dark:hover:text-secondary'>
+        <h1 className='inline font-recipekorea text-2xl md:text-3xl font-bold hover:text-secondary dark:text-text-dark dark:hover:text-blue-600'>
           POSTS
         </h1>
         <div className='flex py-4 gap-8 flex-wrap'>

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image';
+import Link from 'next/link';
+import Comments from '@/components/Comments';
 import IndexNavigation from '@/components/IndexNavigation';
-import { extractHeadings, getPost, processHeadings } from '@/lib/posts';
+import { getPost, processHeadings } from '@/lib/posts';
 import { formatDate } from '@/utils/dateUtils';
 
 interface PostPageProps {
@@ -13,40 +15,45 @@ const PostPage = async ({ params }: PostPageProps) => {
   const { headings, updatedHtml } = processHeadings(contentHtml);
 
   return (
-    <article className='w-full mx-auto p-10 rounded-lg bg-white shadow-md dark:bg-darkActive'>
-      <div className='relative'>
-        <IndexNavigation headings={headings} />
-        <div>
-          <p className='text-2xl md:text-3xl lg:text-4xl font-bold mb-4 pl-0.5 dark:text-text-dark'>
-            {metadata.title}
-          </p>
-          <p className='text-sm md:text-base text-gray-500 mb-4 pl-1'>
-            {formatDate(metadata.date)}
-          </p>
-          <ul className='pb-4 mb-4 border-b border-gray-200 dark:border-text-light'>
-            {metadata.tags.map((tag) => (
-              <li key={tag} className='inline-block leading-9 mr-2'>
-                <span className='bg-gray-200 rounded-3xl px-2.5 py-1 text-sm text-gray-70 dark:bg-gray-500 dark:text-text-dark'>
-                  {tag}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className='relative w-full aspect-video mb-8'>
-          <Image
-            src={metadata.thumbnail}
-            alt={metadata.title}
-            fill
-            className='rounded-lg object-cover'
+    <>
+      <article className='w-full mx-auto p-10 rounded-lg bg-white shadow-md dark:bg-darkActive'>
+        <div className='relative'>
+          <IndexNavigation headings={headings} />
+          <div>
+            <p className='text-2xl md:text-3xl lg:text-4xl font-bold mb-4 pl-0.5 dark:text-text-dark'>
+              {metadata.title}
+            </p>
+            <p className='text-sm md:text-base text-gray-500 mb-4 pl-1'>
+              {formatDate(metadata.date)}
+            </p>
+            <ul className='pb-4 mb-4 border-b border-gray-200 dark:border-text-light'>
+              {metadata.tags.map((tag) => (
+                <li key={tag} className='inline-block leading-9 mr-2'>
+                  <Link href={`/?tags=${tag}`} key={tag}>
+                    <span className='bg-gray-200 rounded-3xl px-2.5 py-1 text-sm text-gray-70 dark:bg-gray-500 dark:text-text-dark'>
+                      {tag}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className='relative w-full aspect-video mb-8'>
+            <Image
+              src={metadata.thumbnail}
+              alt={metadata.title}
+              fill
+              className='rounded-lg object-cover'
+            />
+          </div>
+          <div
+            className='prose dark:prose-dark max-w-none'
+            dangerouslySetInnerHTML={{ __html: updatedHtml }}
           />
         </div>
-        <div
-          className='prose dark:prose-dark max-w-none'
-          dangerouslySetInnerHTML={{ __html: updatedHtml }}
-        />
-      </div>
-    </article>
+      </article>
+      <Comments />
+    </>
   );
 };
 

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const Comments = () => {
+  const getInitialTheme = () =>
+    typeof window !== 'undefined' &&
+    document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    const checkTheme = () => {
+      const isDark = document.documentElement.classList.contains('dark');
+      setTheme(isDark ? 'dark' : 'light');
+
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        'iframe.giscus-frame'
+      );
+
+      if (iframe) {
+        iframe.contentWindow?.postMessage(
+          { giscus: { setConfig: { theme: isDark ? 'dark' : 'light' } } },
+          'https://giscus.app'
+        );
+      }
+    };
+
+    const observer = new MutationObserver(checkTheme);
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    checkTheme();
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (document.querySelector('script#giscus-script')) return;
+
+    const script = document.createElement('script');
+
+    script.id = 'giscus-script';
+    script.src = 'https://giscus.app/client.js';
+    script.setAttribute('data-repo', 'dev-meryoung/mer-log');
+    script.setAttribute('data-repo-id', 'R_kgDON6ue9Q');
+    script.setAttribute('data-category', 'Comments');
+    script.setAttribute('data-category-id', 'DIC_kwDON6ue9c4YnYFV');
+    script.setAttribute('data-mapping', 'pathname');
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'bottom');
+    script.setAttribute('data-lang', 'ko');
+    script.setAttribute('data-theme', theme);
+    script.crossOrigin = 'anonymous';
+    script.async = true;
+
+    document.getElementById('giscus')?.appendChild(script);
+  }, [theme]);
+
+  return (
+    <div
+      id='giscus'
+      className='w-full mx-auto p-10 rounded-lg bg-white shadow-md dark:bg-darkActive mt-4'
+    />
+  );
+};
+
+export default Comments;

--- a/src/components/IndexNavigation.tsx
+++ b/src/components/IndexNavigation.tsx
@@ -87,7 +87,7 @@ const IndexNavigation = ({ headings }: IndexNavigationProps) => {
                   onClick={() => handleClick(heading.id)}
                   className={`text-left w-full ${
                     activeId === heading.id
-                      ? 'text-secondary font-bold dark:text-blue-500'
+                      ? 'text-secondary font-bold dark:text-blue-600'
                       : 'text-gray-700 dark:text-white'
                   } hover:underline`}
                 >

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -26,7 +26,7 @@ const Pagination: React.FC<PaginationProps> = ({
   const baseLinkClasses =
     'px-2.5 py-1 text-sm md:text-base md:px-3 md:py-1 border border-gray-300 rounded dark:border-gray-500';
   const disabledClasses = 'opacity-50 cursor-not-allowed';
-  const activeClasses = 'bg-secondary text-white';
+  const activeClasses = 'bg-secondary text-white dark:bg-blue-600';
 
   return (
     <div className='my-4 flex justify-center items-center space-x-2 dark:text-text-dark'>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -25,7 +25,7 @@ const PostCard: React.FC<PostCardProps> = ({
       />
     </div>
     <div className='relative flex flex-col w-full min-h-[164] md:min-h-[180] md:w-2/3 lg:min-h-[220] lg:w-2/3 p-4 md:px-8 md:py-4 lg:py-6 gap-2'>
-      <h2 className='font-bold text-lg md:text-xl lg:text-2xl line-clamp-2 group-hover:text-secondary dark:text-text-dark'>
+      <h2 className='font-bold text-lg md:text-xl lg:text-2xl line-clamp-2 group-hover:text-secondary dark:group-hover:text-blue-600 dark:text-text-dark'>
         {title}
       </h2>
       <p className='line-clamp-2 text-sm md:text-base text-gray-600 dark:text-gray-300'>

--- a/src/components/ScrollProgressBar.tsx
+++ b/src/components/ScrollProgressBar.tsx
@@ -19,7 +19,10 @@ const ScrollProgressBar = () => {
 
   return (
     <div className='absolute top-0 left-0 w-full h-1 bg-gray-200'>
-      <div className='h-full bg-secondary' style={{ width: `${progress}%` }} />
+      <div
+        className='h-full bg-secondary dark:bg-blue-600'
+        style={{ width: `${progress}%` }}
+      />
     </div>
   );
 };

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -41,8 +41,7 @@ const Tag: React.FC<TagProps> = ({ label }) => {
   return (
     <button
       type='button'
-      className={`flex justify-center items-center text-sm md:text-base gap-1 px-2.5 py-1.5 rounded-3xl bg-gray-200 dark:bg-gray-500 dark:text-text-dark
-        ${active ? 'bg-secondary text-text-dark dark:bg-secondary' : ''}
+      className={`flex justify-center items-center text-sm md:text-base gap-1 px-2.5 py-1.5 rounded-3xl ${active ? 'bg-secondary text-text-dark dark:bg-blue-600' : 'bg-gray-200 dark:bg-gray-500 dark:text-text-dark'}
       `}
       onClick={handleClick}
     >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,6 +49,10 @@ export default {
               marginBottom: '0.5em',
               lineHeight: '1.4',
             },
+            p: {
+              marginBottom: '0.8em',
+              lineHeight: '1.6',
+            },
             img: {
               display: 'block',
               marginLeft: 'auto',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

포스트 상세 페이지 부가 기능 구현

## 📋 작업 내용

- 태그 클릭 시 해당 태그 글 목록으로 이동 기능 구현
- Comments 컴포넌트 구현
- 다크 모드 관련 색상 일부 수정
- 마크다운 문단 간격 수정

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.

## Sourcery 요약

포스트 상세 페이지에 태그 탐색 및 댓글 섹션을 포함한 추가 기능을 구현합니다. 또한 다크 모드 및 마크다운 렌더링에 대한 사소한 스타일 조정도 포함되어 있습니다.

새로운 기능:
- 태그를 클릭할 때 해당 태그의 포스트 목록으로 이동하는 기능을 구현했습니다.
- Giscus를 사용하여 포스트에 댓글을 달 수 있도록 댓글 컴포넌트를 추가했습니다.

개선 사항:
- 더 나은 가독성을 위해 마크다운 단락 사이의 간격을 조정했습니다.
- 사용자 경험을 개선하기 위해 다크 모드와 관련된 일부 색상을 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implements additional features for the post detail page, including tag navigation and a comments section. It also includes minor style adjustments for dark mode and markdown rendering.

New Features:
- Implemented navigation to a tag's posts list when clicking on a tag.
- Added a Comments component using Giscus to enable commenting on posts.

Enhancements:
- Adjusted the margin between markdown paragraphs for better readability.
- Modified some colors related to dark mode to improve the user experience.

</details>