### PR TITLE
[Fix] Params Promise Type 불일치 문제 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,14 +5,11 @@ import Tag from '@/components/Tag';
 import { getAllPosts, getAllTags } from '@/lib/posts';
 
 interface HomeProps {
-  searchParams: {
-    page?: string;
-    tags?: string;
-  };
+  searchParams: Promise<{ page?: string; tags?: string }>;
 }
 
 const Home = async (props: HomeProps) => {
-  const searchParams = await Promise.resolve(props.searchParams);
+  const searchParams = await props.searchParams;
   const allPosts = getAllPosts();
   const allTags = getAllTags();
 

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -6,11 +6,12 @@ import { getPost, processHeadings } from '@/lib/posts';
 import { formatDate } from '@/utils/dateUtils';
 
 interface PostPageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 const PostPage = async ({ params }: PostPageProps) => {
-  const post = await getPost(params.slug);
+  const { slug } = await params;
+  const post = await getPost(slug);
   const { metadata, contentHtml } = post;
   const { headings, updatedHtml } = processHeadings(contentHtml);
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Page에서 사용되는 Params의 Promise Type 불일치 문제 수정

## 📋 작업 내용

- Params Promise Type 불일치 문제 수정

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.

## Sourcery 요약

버그 수정:
- `Params` 타입이 Promise로 올바르게 정의되지 않아 `Home` 및 `PostPage` 컴포넌트에서 타입 불일치가 발생하는 문제를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the `Params` type was not correctly defined as a Promise, causing type mismatches in the `Home` and `PostPage` components.

</details>