### PR TITLE
[Chore] 본문 내 이미지에 Next/Image 태그 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "date-fns": "^4.1.0",
         "gray-matter": "^4.0.3",
+        "image-size": "^2.0.0",
         "next": "15.1.7",
         "next-mdx-remote": "^5.0.0",
         "plaiceholder": "^3.0.0",
@@ -4594,6 +4595,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.0.tgz",
+      "integrity": "sha512-HP07n1SpdIXGUL4VotUIOQz66MQOq8g7VN+Yj02YTVowqZScQ5i/JYU0+lkNr2pwt5j4hOpk94/UBV1ZCbS2fA==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^2.2.0",
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",
+    "image-size": "^2.0.0",
     "next": "15.1.7",
     "next-mdx-remote": "^5.0.0",
     "plaiceholder": "^3.0.0",

--- a/src/components/MDXComponents.tsx
+++ b/src/components/MDXComponents.tsx
@@ -9,15 +9,17 @@ interface MDXImageProps {
 }
 
 const MDXImage = async ({ src, alt = 'image' }: MDXImageProps) => {
-  const imageBlur = await generateBlurDataForImage(src);
-  const { width, height } = await getImageSize(src);
+  const [imageBlur, imageSize] = await Promise.all([
+    generateBlurDataForImage(src),
+    getImageSize(src),
+  ]);
 
   return (
     <Image
       src={src}
       alt={alt}
-      width={width}
-      height={height}
+      width={imageSize.width}
+      height={imageSize.height}
       className='max-w-full h-auto object-cover rounded-lg'
       placeholder='blur'
       blurDataURL={imageBlur}

--- a/src/components/MDXComponents.tsx
+++ b/src/components/MDXComponents.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import { generateBlurDataForImage, getImageSize } from '@/lib/images';
+
+interface MDXImageProps {
+  src: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+const MDXImage = async ({ src, alt = 'image' }: MDXImageProps) => {
+  const imageBlur = await generateBlurDataForImage(src);
+  const { width, height } = await getImageSize(src);
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className='max-w-full h-auto object-cover rounded-lg'
+      placeholder='blur'
+      blurDataURL={imageBlur}
+    />
+  );
+};
+
+const MDXComponents = {
+  img: MDXImage,
+};
+
+export default MDXComponents;

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import imageSize from 'image-size';
 import { getPlaiceholder } from 'plaiceholder';
 
 export const generateBlurDataForImage = async (imagePath: string) => {
@@ -10,7 +11,34 @@ export const generateBlurDataForImage = async (imagePath: string) => {
   }
 
   const fileBuffer = fs.readFileSync(fullPath);
-  const { base64 } = await getPlaiceholder(fileBuffer, { size: 32 });
+  const { base64 } = await getPlaiceholder(fileBuffer, { size: 64 });
 
   return base64;
+};
+
+export const getImageSize = async (src: string) => {
+  if (src.startsWith('/')) {
+    const fullPath = path.join(process.cwd(), 'public', src);
+
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Image not found: ${fullPath}`);
+    }
+
+    const fileBuffer = fs.readFileSync(fullPath);
+    const dimensions = imageSize(fileBuffer);
+
+    return {
+      width: dimensions.width || 1280,
+      height: dimensions.height || 720,
+    };
+  }
+
+  const res = await fetch(src);
+  const buffer = await res.arrayBuffer();
+  const dimensions = imageSize(Buffer.from(buffer));
+
+  return {
+    width: dimensions.width || 1280,
+    height: dimensions.height || 720,
+  };
 };

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -3,6 +3,39 @@ import path from 'path';
 import imageSize from 'image-size';
 import { getPlaiceholder } from 'plaiceholder';
 
+const computeDimensions = (buffer: Buffer) => {
+  const dimensions = imageSize(buffer);
+
+  return {
+    width: dimensions.width || 1280,
+    height: dimensions.height || 720,
+  };
+};
+
+export const getImageSize = async (src: string) => {
+  let buffer: Buffer;
+
+  if (src.startsWith('/')) {
+    const fullPath = path.join(process.cwd(), 'public', src);
+
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(fullPath);
+    }
+
+    buffer = fs.readFileSync(fullPath);
+  } else {
+    const res = await fetch(src);
+
+    if (!res.ok) {
+      throw new Error(src);
+    }
+
+    buffer = Buffer.from(await res.arrayBuffer());
+  }
+
+  return computeDimensions(buffer);
+};
+
 export const generateBlurDataForImage = async (imagePath: string) => {
   const fullPath = path.join(process.cwd(), 'public', imagePath);
 
@@ -14,31 +47,4 @@ export const generateBlurDataForImage = async (imagePath: string) => {
   const { base64 } = await getPlaiceholder(fileBuffer, { size: 64 });
 
   return base64;
-};
-
-export const getImageSize = async (src: string) => {
-  if (src.startsWith('/')) {
-    const fullPath = path.join(process.cwd(), 'public', src);
-
-    if (!fs.existsSync(fullPath)) {
-      throw new Error(`Image not found: ${fullPath}`);
-    }
-
-    const fileBuffer = fs.readFileSync(fullPath);
-    const dimensions = imageSize(fileBuffer);
-
-    return {
-      width: dimensions.width || 1280,
-      height: dimensions.height || 720,
-    };
-  }
-
-  const res = await fetch(src);
-  const buffer = await res.arrayBuffer();
-  const dimensions = imageSize(Buffer.from(buffer));
-
-  return {
-    width: dimensions.width || 1280,
-    height: dimensions.height || 720,
-  };
 };

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { ReactElement } from 'react';
 import matter from 'gray-matter';
 import { compileMDX, MDXRemoteProps } from 'next-mdx-remote/rsc';
+import MDXComponents from '@/components/MDXComponents';
 import { compareDatesDesc } from '@/utils/dateUtils';
 
 export interface PostInfo {
@@ -99,6 +100,7 @@ export const getPost = async (slug: string): Promise<PostData> => {
   const { content: mdxSource } = await compileMDX<MDXRemoteProps>({
     source: updatedMdx,
     options: { parseFrontmatter: false },
+    components: MDXComponents,
   });
 
   const summary = extractParagraphs(content, 150);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

본문 내 이미지에 Next/Image 태그 적용 외 작업

## 📋 작업 내용

- 본문 내 이미지에 Next/Image 태그 적용
- image-size 라이브러리 설치
- 이미지 원본 크기 관련 로직 추가

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.

## Sourcery에 의한 요약

콘텐츠 내 이미지에 Next/Image 태그를 적용하여 이미지 최적화 및 로딩 성능을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Applies the Next/Image tag to images within the content, enhancing image optimization and loading performance.

</details>