### PR TITLE
[Config] Pre-commit Hook 최적화 작업

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,12 @@
-pre-commit:
-  parallel: true
-  commands:
-    eslint:
-      run: npm run lint
-
 commit-msg:
   commands:
     commitlint:
       glob: commit-msg
-      run: npx commitlint --edit
+      run: npx commitlint --edit {1}
+
+pre-commit:
+  parallel: true
+  commands:
+    lint-and-format:
+      glob: '**/*.{js,jsx,ts,tsx}'
+      run: npx prettier --write {staged_files} && npx eslint --fix {staged_files} && git add {staged_files}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

프로젝트 내 전체 파일 대상으로 수행하던 Lint를 Staged 파일만 검사하도록 수정

## 📋 작업 내용

- Lefthook 설정 변경

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.

## Sourcery 요약

Lefthook 설정을 개선하여 린팅을 스테이징된 파일로 제한하고, commitlint에 올바른 파일 인수를 전달합니다.

개선 사항:
- pre-commit 훅을 최적화하여 Prettier와 ESLint로 스테이징된 JS/TS 파일만 린트하고 포맷하며, 해당 파일들을 다시 추가합니다.
- commit-msg 훅을 업데이트하여 커밋 메시지 파일 경로를 commitlint에 올바르게 전달합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Lefthook configuration by restricting linting to staged files and passing the correct file argument to commitlint

Enhancements:
- Optimize pre-commit hook to lint and format only staged JS/TS files with Prettier and ESLint and re-add the files
- Update commit-msg hook to correctly pass the commit message file path to commitlint

</details>