### PR TITLE
[Chore] 검색 결과 페이지 UX 개선 작업

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,7 +1,7 @@
+import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import SearchResultsWrapper from '@/components/SearchResultsWrapper';
-import { getAllPosts, getAllSearchPosts } from '@/lib/posts';
-import { compareDatesDesc } from '@/utils/dateUtils';
+import Loading from './loading';
 
 const SearchPage = async ({
   searchParams,
@@ -15,37 +15,10 @@ const SearchPage = async ({
     notFound();
   }
 
-  const [searchPosts, allPosts] = await Promise.all([
-    getAllSearchPosts(),
-    getAllPosts(),
-  ]);
-
-  const lowerKeyword = trimmedKeyword.toLowerCase();
-
-  const matchedSlugs = new Set(
-    searchPosts
-      .filter((post) => {
-        const titleMatch = post.title.toLowerCase().includes(lowerKeyword);
-        const descMatch = post.description.toLowerCase().includes(lowerKeyword);
-        const contentMatch = post.content.toLowerCase().includes(lowerKeyword);
-        const tagMatch = post.tags.some((tag) =>
-          tag.toLowerCase().includes(lowerKeyword)
-        );
-
-        return titleMatch || descMatch || contentMatch || tagMatch;
-      })
-      .map((post) => post.slug)
-  );
-
-  const filteredPosts = allPosts
-    .filter((post) => matchedSlugs.has(post.slug))
-    .sort((a, b) => compareDatesDesc(a.date, b.date));
-
   return (
-    <SearchResultsWrapper
-      initialPosts={filteredPosts}
-      keyword={trimmedKeyword}
-    />
+    <Suspense fallback={<Loading />}>
+      <SearchResultsWrapper keyword={trimmedKeyword} />
+    </Suspense>
   );
 };
 

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  notFound,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from 'next/navigation';
+import { PostInfo } from '@/types/post';
+import PostList from './PostList';
+
+interface SearchResultsProps {
+  initialPosts: PostInfo[];
+  keyword: string;
+}
+
+const SearchResults = ({ initialPosts, keyword }: SearchResultsProps) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentPage = Number(searchParams.get('page')) || 1;
+
+  const postsPerPage = 5;
+  const totalPages = Math.ceil(initialPosts.length / postsPerPage);
+  const currentPosts = initialPosts.slice(
+    (currentPage - 1) * postsPerPage,
+    currentPage * postsPerPage
+  );
+
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.set('page', page.toString());
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <>
+      <h1 className='inline-block text-2xl md:text-3xl font-semibold my-4 md:my-8'>
+        <span className='text-secondary dark:text-blue-700'>{`🔍'${keyword}'`}</span>
+        <span className='text-gray-800 dark:text-gray-200'>
+          에 대한 검색 결과
+        </span>
+        <span className='text-lg md:text-xl ml-1 font-normal text-gray-500'>
+          ({initialPosts.length}개)
+        </span>
+      </h1>
+
+      {initialPosts.length > 0 ? (
+        <PostList
+          posts={currentPosts}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+      ) : (
+        <div className='py-40 text-center text-gray-500'>
+          <p className='text-sm md:text-lg'>
+            {keyword ? `'${keyword}'에 대한 검색 결과가 없습니다.` : notFound()}
+          </p>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SearchResults;

--- a/src/components/SearchResultsWrapper.tsx
+++ b/src/components/SearchResultsWrapper.tsx
@@ -1,70 +1,39 @@
-'use client';
-
-import {
-  notFound,
-  usePathname,
-  useRouter,
-  useSearchParams,
-} from 'next/navigation';
-import { PostInfo } from '@/types/post';
-import PostList from './PostList';
+import SearchResults from '@/components/SearchResults';
+import { getAllPosts, getAllSearchPosts } from '@/lib/posts';
+import { compareDatesDesc } from '@/utils/dateUtils';
 
 interface SearchResultsWrapperProps {
-  initialPosts: PostInfo[];
   keyword: string;
 }
 
-const SearchResultsWrapper = ({
-  initialPosts,
-  keyword,
-}: SearchResultsWrapperProps) => {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-  const currentPage = Number(searchParams.get('page')) || 1;
+const SearchResultsWrapper = async ({ keyword }: SearchResultsWrapperProps) => {
+  const [searchPosts, allPosts] = await Promise.all([
+    getAllSearchPosts(),
+    getAllPosts(),
+  ]);
 
-  const postsPerPage = 5;
-  const totalPages = Math.ceil(initialPosts.length / postsPerPage);
-  const currentPosts = initialPosts.slice(
-    (currentPage - 1) * postsPerPage,
-    currentPage * postsPerPage
+  const lowerKeyword = keyword.toLowerCase();
+
+  const matchedSlugs = new Set(
+    searchPosts
+      .filter((post) => {
+        const titleMatch = post.title.toLowerCase().includes(lowerKeyword);
+        const descMatch = post.description.toLowerCase().includes(lowerKeyword);
+        const contentMatch = post.content.toLowerCase().includes(lowerKeyword);
+        const tagMatch = post.tags.some((tag) =>
+          tag.toLowerCase().includes(lowerKeyword)
+        );
+
+        return titleMatch || descMatch || contentMatch || tagMatch;
+      })
+      .map((post) => post.slug)
   );
 
-  const handlePageChange = (page: number) => {
-    const params = new URLSearchParams(searchParams.toString());
+  const filteredPosts = allPosts
+    .filter((post) => matchedSlugs.has(post.slug))
+    .sort((a, b) => compareDatesDesc(a.date, b.date));
 
-    params.set('page', page.toString());
-    router.push(`${pathname}?${params.toString()}`);
-  };
-
-  return (
-    <>
-      <h1 className='inline-block text-2xl md:text-3xl font-semibold my-4 md:my-8'>
-        <span className='text-secondary dark:text-blue-700'>{`🔍'${keyword}'`}</span>
-        <span className='text-gray-800 dark:text-gray-200'>
-          에 대한 검색 결과
-        </span>
-        <span className='text-lg md:text-xl ml-1 font-normal text-gray-500'>
-          ({initialPosts.length}개)
-        </span>
-      </h1>
-
-      {initialPosts.length > 0 ? (
-        <PostList
-          posts={currentPosts}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-        />
-      ) : (
-        <div className='py-40 text-center text-gray-500'>
-          <p className='text-sm md:text-lg'>
-            {keyword ? `'${keyword}'에 대한 검색 결과가 없습니다.` : notFound()}
-          </p>
-        </div>
-      )}
-    </>
-  );
+  return <SearchResults initialPosts={filteredPosts} keyword={keyword} />;
 };
 
 export default SearchResultsWrapper;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

키워드 검색 시 즉각적인 라우팅 이후 로딩을 거쳐 결과를 보여줄 수 있도록 수정

## 📋 작업 내용

- 검색 결과 페이지 Suspense 비동기 로딩 처리
- 검색 데이터 로직 서버 컴포넌트로 이관

## 📝 메모

추가적으로 전달하고 싶은 내용이나 참고를 위한 스크린샷을 첨부해 주세요.
